### PR TITLE
Fix: Type error in the `balance_check` job

### DIFF
--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -1,12 +1,15 @@
 """Tests for triton.chain module"""
 import datetime
+from decimal import Decimal
 from http import HTTPStatus
 from unittest.mock import Mock, patch, MagicMock, mock_open
 import pytz
+from operate.operate_types import Chain
 from web3.exceptions import ABIFunctionNotFound
 
 from triton.chain import (
     get_native_balance,
+    get_wrapped_native_balance,
     load_contract,
     get_olas_balance,
     get_mech_request_count,
@@ -63,6 +66,30 @@ class TestLoadContract:
             address="0x1234567890abcdef1234567890abcdef12345678",
             abi=[{"name": "test"}]
         )
+
+
+class TestGetWrappedNativeBalance:
+    """Tests for get_wrapped_native_balance function"""
+
+    @patch('triton.chain.load_contract')
+    def test_get_wrapped_native_balance_uses_token_decimals(
+        self, mock_load_contract
+    ):
+        """Test wrapped native balance is converted using ERC20 decimals."""
+        mock_contract = MagicMock()
+        mock_contract.functions.balanceOf.return_value.call.return_value = 300000
+        mock_contract.functions.decimals.return_value.call.return_value = 6
+        mock_load_contract.return_value = mock_contract
+
+        result = get_wrapped_native_balance(
+            "0x1234567890abcdef1234567890abcdef12345678", Chain.GNOSIS
+        )
+
+        assert result == Decimal("0.3")
+        mock_contract.functions.balanceOf.assert_called_once_with(
+            "0x1234567890abcdef1234567890abcdef12345678"
+        )
+        mock_contract.functions.decimals.assert_called_once_with()
     
     @patch('builtins.open', new_callable=mock_open, read_data='[{"name": "test"}]')
     @patch('triton.chain.web3')

--- a/triton/chain.py
+++ b/triton/chain.py
@@ -6,6 +6,7 @@ import json
 import logging
 import math
 import os
+from decimal import Decimal
 from http import HTTPStatus
 from pathlib import Path
 from typing import cast
@@ -61,17 +62,14 @@ def load_contract(
     return contract
 
 
-def get_wrapped_native_balance(address: str, chain: ChainType) -> float:
+def get_wrapped_native_balance(address: str, chain: ChainType):
     """Get the wrapped native balance"""
-    return (
-        load_contract(WRAPPED_NATIVE_ASSET[chain], "erc20", has_abi_key=False)
-        .functions.balanceOf(address)
-        .call()
-        / 10
-        ** load_contract(WRAPPED_NATIVE_ASSET[chain], "erc20", has_abi_key=False)
-        .functions.decimals()
-        .call()
+    wrapped_native_contract = load_contract(
+        WRAPPED_NATIVE_ASSET[chain], "erc20", has_abi_key=False
     )
+    wrapped_native_balance = wrapped_native_contract.functions.balanceOf(address).call()
+    wrapped_native_decimals = wrapped_native_contract.functions.decimals().call()
+    return Decimal(wrapped_native_balance) / (Decimal(10) ** wrapped_native_decimals)
 
 
 def get_olas_balance(address: str):


### PR DESCRIPTION
Fix this error in the `balance-check` job
```
Feb 18 03:45:16 pi triton[825447]: [2026-02-18 03:45:16,995][ERROR] No error handlers are registered, logging exception.
Feb 18 03:45:16 pi triton[825447]: Traceback (most recent call last):
Feb 18 03:45:16 pi triton[825447]:   File "/home/oj/.cache/pypoetry/virtualenvs/triton-WDiFYlvC-py3.11/lib/python3.11/site-packages/telegram/ext/_jobqueue.py", line 997, in _run
Feb 18 03:45:16 pi triton[825447]:     await self.callback(context)
Feb 18 03:45:16 pi triton[825447]:   File "/home/oj/Documents/repos/triton-bot/triton/triton.py", line 314, in balance_check
Feb 18 03:45:16 pi triton[825447]:     safe_native_balance + safe_wrapped_native_balance
Feb 18 03:45:16 pi triton[825447]:     ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Feb 18 03:45:16 pi triton[825447]: TypeError: unsupported operand type(s) for +: 'decimal.Decimal' and 'float'
```